### PR TITLE
chore: clean quic code

### DIFF
--- a/protocol/juicity/dialer.go
+++ b/protocol/juicity/dialer.go
@@ -52,8 +52,6 @@ func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dia
 						MaxStreamReceiveWindow:         common.MaxStreamReceiveWindow,
 						InitialConnectionReceiveWindow: common.InitialConnectionReceiveWindow,
 						MaxConnectionReceiveWindow:     common.MaxConnectionReceiveWindow,
-						MaxIncomingStreams:             quicMaxOpenIncomingStreams,
-						MaxIncomingUniStreams:          quicMaxOpenIncomingStreams,
 						KeepAlivePeriod:                5 * time.Second,
 						DisablePathMTUDiscovery:        false,
 						EnableDatagrams:                true,

--- a/protocol/tuic/common/congestion.go
+++ b/protocol/tuic/common/congestion.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	InitialStreamReceiveWindow     = 2 * 1024 * 1024  // 2 MB
-	MaxStreamReceiveWindow         = 32 * 1024 * 1024 // 16 MB
+	MaxStreamReceiveWindow         = 32 * 1024 * 1024 // 32 MB
 	InitialConnectionReceiveWindow = 32 * 1024 * 1024 // 32 MB
 	MaxConnectionReceiveWindow     = 64 * 1024 * 1024 // 64 MB
 )
@@ -35,6 +35,8 @@ func SetCongestionController(quicConn quic.Connection, cc string, cwnd int) {
 			),
 		)
 	case "bbr":
+		fallthrough
+	default:
 		quicConn.SetCongestionControl(
 			congestion.NewBBRSender(
 				congestion.DefaultClock{},


### PR DESCRIPTION
### Changelogs

1. Remove `quicMaxOpenIncomingStreams` on the client side.
2. Use `bbr` as CC by default.