### PR TITLE
ci: add monitor-upstream-releases workflow

### DIFF
--- a/.github/workflows/monitor-upstream-releases.yml
+++ b/.github/workflows/monitor-upstream-releases.yml
@@ -9,7 +9,7 @@
 #  This is a open-source software, liscensed under the AGPL-3.0 License.
 #  See /License for more information.
 
-# Reference: https://github.com/marketplace/actions/rss-to-issues
+#  Reference: https://github.com/marketplace/actions/rss-to-issues
 
 name: Monitor new upstream git release versions
 

--- a/.github/workflows/monitor-upstream-releases.yml
+++ b/.github/workflows/monitor-upstream-releases.yml
@@ -1,0 +1,47 @@
+#       _
+#    __| | __ _  ___
+#   / _` |/ _` |/ _ \
+#  | (_| | (_| |  __/
+#   \__,_|\__,_|\___|
+# 
+#  Copyright (C) 2023 @daeuniverse <https://github.com/daeuniverse>
+# 
+#  This is a open-source software, liscensed under the AGPL-3.0 License.
+#  See /License for more information.
+
+# Reference: https://github.com/marketplace/actions/rss-to-issues
+
+name: Monitor new upstream git release versions
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run this Action every day at 4:00pm UTC
+    - cron: "0 16 * * *"
+
+env:
+  CHARACTER_LIMIT: 1000
+  MAX_AGE: 7d
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    strategy:
+      matrix:
+        include:
+          - project: quic-go
+            labels: quic-go/quic-go
+            feed: https://github.com/quic-go/quic-go/releases.atom
+      fail-fast: false
+    steps:
+      - uses: git-for-windows/rss-to-issues@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: ${{ matrix.feed }}
+          prefix: "[New ${{ matrix.project }} version]"
+          character-limit: ${{ env.CHARACTER_LIMIT }}
+          dry-run: true
+          max-age: ${{ env.MAX_AGE }}
+          labels: github/release,automated-issue,${{ matrix.labels }}

--- a/.github/workflows/monitor-upstream-releases.yml
+++ b/.github/workflows/monitor-upstream-releases.yml
@@ -42,6 +42,6 @@ jobs:
           feed: ${{ matrix.feed }}
           prefix: "[New ${{ matrix.project }} version]"
           character-limit: ${{ env.CHARACTER_LIMIT }}
-          dry-run: true
+          dry-run: false
           max-age: ${{ env.MAX_AGE }}
           labels: github/release,automated-issue,${{ matrix.labels }}


### PR DESCRIPTION
## Summary

Add a new workflow for monitoring multiple upstream releases.

Reference: https://github.com/git-for-windows/git/issues/4734

Usage: https://github.com/vertexbox/github-seed-actions/blob/master/github/rss-to-issue/README.md

## Benefit

We may make use of this workflow to monitor necessary upstream releases. The workflow monitors changes and creates GitHub issues accordingly.

## How it works

As described in [github-marketplace/rss-to-issue](https://github.com/marketplace/actions/rss-to-issues), it is a simple GitHub Composite Action to monitor RSS or atom feed and create GitHub issues if the feed has updated within a custom time frame.

## PoC (Proof of Concept)

https://github.com/yqlbu/github-seed-actions/actions/runs/7375859329/job/20067918308

https://github.com/yqlbu/github-seed-actions/issues/1

![image](https://github.com/daeuniverse/softwind/assets/151038614/07021dc5-b5a3-42b0-9cfb-01e2fe21b21f)

![image](https://github.com/daeuniverse/softwind/assets/151038614/77b3339b-e689-4328-a5f0-665d6c23c468)
